### PR TITLE
Fixing enums

### DIFF
--- a/generators/ir2c/templates/Heavy_NAME.hpp
+++ b/generators/ir2c/templates/Heavy_NAME.hpp
@@ -29,7 +29,7 @@ class Heavy_{{name}} : public HeavyContext {
   struct Parameter {
     {% if externs.parameters.in|length > 0 -%}
     struct In {
-      enum ParameterIn : hv_uint32_t {
+      enum ParameterIn {
         {%- for k,v in externs.parameters.in %}
         {{k|upper}} = {{v.hash}}, // {{v.display}}
         {%- endfor %}
@@ -39,7 +39,7 @@ class Heavy_{{name}} : public HeavyContext {
 
     {%- if externs.parameters.out|length > 0 %}
     struct Out {
-      enum ParameterOut : hv_uint32_t {
+      enum ParameterOut {
         {%- for k,v in externs.parameters.out %}
         {{k|upper}} = {{v.hash}}, // {{v.display}}
         {%- endfor %}
@@ -53,7 +53,7 @@ class Heavy_{{name}} : public HeavyContext {
   struct Event {
     {%- if externs.events.in|length > 0 %}
     struct In {
-      enum EventIn : hv_uint32_t {
+      enum EventIn {
         {%- for k,v in externs.events.in %}
         {{k|upper}} = {{v.hash}}, // {{v.display}}
         {%- endfor %}
@@ -63,7 +63,7 @@ class Heavy_{{name}} : public HeavyContext {
 
     {%- if externs.events.out|length > 0 %}
     struct Out {
-      enum EventOut : hv_uint32_t {
+      enum EventOut {
         {%- for k,v in externs.events.out %}
         {{k|upper}} = {{v.hash}}, // {{v.display}}
         {%- endfor %}
@@ -74,7 +74,7 @@ class Heavy_{{name}} : public HeavyContext {
   {%- endif %}
 
   {%- if externs.tables|length > 0 %}
-  enum Table : hv_uint32_t {
+  enum Table {
     {%- for k,v in externs.tables %}
     {{k|upper}} = {{v.hash}}, // {{v.display}}
     {%- endfor %}

--- a/hvcc.py
+++ b/hvcc.py
@@ -337,7 +337,7 @@ def main():
     parser.add_argument(
         "-p",
         "--search_paths",
-        nargs="+",
+        action="append",
         help="Add a list of directories to search through for abstractions.")
     parser.add_argument(
         "-n",

--- a/hvcc.py
+++ b/hvcc.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python2.7
+
 # Copyright (C) 2014-2018 Enzien Audio, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify

--- a/interpreters/pd2hv/PdParser.py
+++ b/interpreters/pd2hv/PdParser.py
@@ -109,15 +109,18 @@ class PdParser:
                 else:
                     concat = (concat + " " + l) if len(concat) > 0 else l
 
-    def add_relative_search_directory(self, search_dir):
-        search_dir = os.path.abspath(os.path.join(
-            self.__search_paths[0],
-            search_dir))
+    def add_absolute_search_directory(self, search_dir):
         if os.path.isdir(search_dir):
             self.__search_paths.append(search_dir)
             return True
         else:
             return False
+
+    def add_relative_search_directory(self, search_dir):
+        search_dir = os.path.abspath(os.path.join(
+            self.__search_paths[0],
+            search_dir))
+        return self.add_absolute_search_directory(search_dir)
 
     def find_abstraction_path(self, local_dir, abs_name):
         """ Finds the full path for an abstraction.

--- a/interpreters/pd2hv/pd2hv.py
+++ b/interpreters/pd2hv/pd2hv.py
@@ -43,6 +43,11 @@ class pd2hv:
         tick = time.time()
 
         parser = PdParser() # create parser state
+
+        if search_paths is not None:
+            for p in search_paths:
+                parser.add_absolute_search_directory(p)
+
         pd_graph = parser.graph_from_file(pd_path)
         notices = pd_graph.get_notices()
 


### PR DESCRIPTION
The c template uses enum definitions in the form
enum: uint32_t { ... }
which is not acceptable in modern C standards, resulting in compilation errors.
The uint32_t is (apparently) not really necessary, therefore deleted with this PR.